### PR TITLE
change order of loading GNU libstdc++.so.6 and LLVM libc++.so.1

### DIFF
--- a/cxxfilt/__init__.py
+++ b/cxxfilt/__init__.py
@@ -39,7 +39,7 @@ def find_any_library(*choices):
 libc = ctypes.CDLL(find_any_library('c'))
 libc.free.argtypes = [ctypes.c_void_p]
 
-libcxx = ctypes.CDLL(find_any_library('c++', 'stdc++'))
+libcxx = ctypes.CDLL(find_any_library('stdc++', 'c++'))
 libcxx.__cxa_demangle.restype = CharP
 
 


### PR DESCRIPTION
change order of loading GNU libstdc++.so.6 and LLVM libc++.so.1, since the former appears to demangle very differently.