### PR TITLE
Fix compatibility issue that did't work on py3.5

### DIFF
--- a/cxxfilt/__init__.py
+++ b/cxxfilt/__init__.py
@@ -71,7 +71,7 @@ class Demangler(BaseDemangler):
         self._cxa_demangle.restype = CharP
 
     def __repr__(self) -> str:
-        return f'<{self.__class__.__name__} libc={self._libc_name!r} libcxx={self._libcxx_name!r}>'
+        return '<{} libc={!r} libcxx={!r}>'.format(self.__class__.__name__, self._libc_name, self._libcxx_name)
 
     def demangleb(self, mangled_name: bytes, external_only: bool = True) -> bytes:
         # Wikipedia: All *external* mangled symbols begin with _Z
@@ -116,7 +116,7 @@ def _get_default_demangler() -> BaseDemangler:
     return Demangler(libc, libcxx)
 
 
-default_demangler: BaseDemangler = _get_default_demangler()
+default_demangler = _get_default_demangler()
 
 
 def demangle(mangled_name: str, external_only: bool = True) -> str:


### PR DESCRIPTION
cxxfilt is present in the Python 3.5 py source but cannot be used due to compatibility issues.

```
  File "/usr/local/lib/python3.5/dist-packages/cxxfilt/__init__.py", line 74
    return f'<{self.__class__.__name__} libc={self._libc_name!r} libcxx={self._libcxx_name!r}>'

  File "/usr/local/lib/python3.5/dist-packages/cxxfilt/__init__.py", line 119
    default_demangler: BaseDemangler = _get_default_demangler()
```
